### PR TITLE
Fix failing test script

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -101,7 +101,7 @@ function create (dir, argv) {
     },
     function (done) {
       var pkgs = [
-        'bankai@9',
+        'bankai@next',
         'dependency-check@2',
         'electron@1',
         'electron-builder@19',

--- a/bin.js
+++ b/bin.js
@@ -88,12 +88,12 @@ function create (dir, argv) {
       print('\nInstalling packages, this might take a couple of minutes.')
       written.push(path.join(dir, 'node_modules'))
       var pkgs = [
-        'choo',
-        'choo-log',
-        'choo-devtools',
-        'electron-collection',
-        'sheetify',
-        'tachyons'
+        'choo@6',
+        'choo-log@7',
+        'choo-devtools@1',
+        'electron-collection@1',
+        'sheetify@6',
+        'tachyons@4'
       ]
       var msg = clrInstall(pkgs)
       print('Installing ' + msg + '…')
@@ -101,12 +101,12 @@ function create (dir, argv) {
     },
     function (done) {
       var pkgs = [
-        'bankai@next',
-        'dependency-check',
-        'electron',
-        'electron-builder',
-        'electron-builder-squirrel-windows',
-        'standard'
+        'bankai@9',
+        'dependency-check@2',
+        'electron@1',
+        'electron-builder@19',
+        'electron-builder-squirrel-windows@19',
+        'standard@10'
       ]
       var msg = clrInstall(pkgs)
       print('Installing ' + msg + '…')

--- a/bin.js
+++ b/bin.js
@@ -92,6 +92,7 @@ function create (dir, argv) {
         'choo-log',
         'choo-devtools',
         'electron-collection',
+        'sheetify',
         'tachyons'
       ]
       var msg = clrInstall(pkgs)
@@ -101,6 +102,7 @@ function create (dir, argv) {
     function (done) {
       var pkgs = [
         'bankai@next',
+        'dependency-check',
         'electron',
         'electron-builder',
         'electron-builder-squirrel-windows',

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ exports.writePackage = function (dir, cb) {
       "inspect": "bankai inspect index.js",
       "pack": "bankai build && build --dir",
       "start": "NODE_ENV=development electron main.js",
-      "test": "standard && test-deps",
-      "test-deps": "dependency-check . && dependency-check . --extra --no-dev -i tachyons"
+      "test": "standard && npm run test-deps",
+      "test-deps": "dependency-check . --entry index.js && dependency-check . --entry index.js --extra --no-dev -i tachyons"
     },
     "build": {
       "appId": "${name}",
@@ -129,7 +129,7 @@ exports.writeIndex = function (dir, cb) {
     app.route('/*', require('./views/404'))
 
     if (!module.parent) app.mount('body')
-    else module.exports = app
+    else module.exports = app\n
   `
 
   write(filename, file, cb)
@@ -189,7 +189,7 @@ exports.writeMain = function (dir, cb) {
         if (win.isMinimized()) win.restore()
         win.focus()
       }
-    }
+    }\n
   `
 
   write(filename, file, cb)
@@ -217,7 +217,7 @@ exports.writeNotFoundView = function (dir, cb) {
           </a>
         </body>
       \`
-    }
+    }\n
   `
 
   mkdirp(dirname, function (err) {
@@ -245,7 +245,7 @@ exports.writeMainView = function (dir, cb) {
           </h1>
         </body>
       \`
-    }
+    }\n
   `
 
   mkdirp(dirname, function (err) {


### PR DESCRIPTION
This aims to make the `npm test` script succeed for the generated project and to make the generated project use choo v6:

1. `npm test` is failing because:
  a. standard is failing, because the generated JavaScript files doesn't have a blank line at the end.
  b. The `test` script is running `test-deps` without the `npm run` "prefix".
  c. dependency-check is not included as a dev dependency.
  d. sheetify is not included as a dependency.
  e. Since `main.js` doesn't require `index.js`, dependency-check is finding some "unused dependencies".

2. Since the npm install is running with the `--cache-min` parameter set to `Infinity`, it was installing choo@5 for me. I realized this because I could see an error in the dev console saying something like `TypeError: Cannot read property 'DOMTITLECHANGE' of undefined`. My proposal is to specify the desired major versions for the dependencies. But maybe not using `--cache-min` could be another way to solve it.