### PR TITLE
Remove the setting of 'NODE_ENV' within the generated content

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ exports.writePackage = function (dir, cb) {
       "dev": "bankai start index.js",
       "inspect": "bankai inspect index.js",
       "pack": "bankai build && build --dir",
-      "start": "NODE_ENV=development electron main.js",
+      "start": "electron main.js",
       "test": "standard && test-deps",
       "test-deps": "dependency-check . && dependency-check . --extra --no-dev -i tachyons"
     },
@@ -170,7 +170,7 @@ exports.writeMain = function (dir, cb) {
         win.show()
         var menu = Menu.buildFromTemplate(defaultMenu(app, electron.shell))
         Menu.setApplicationMenu(menu)
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV !== 'production') {
           win.webContents.openDevTools({ mode: 'detach' })
         }
       })


### PR DESCRIPTION
As per #1, this removes the setting of 'NODE_ENV' from the generated `package.json`. I also switched around a check for the `NODE_ENV` to cover when not running as production.

I had some issues testing, even when trying out the the project without my changes the application is unable to find either `bundle.js` or `bundle.css` therefore just displays a blank electron window. I tried both `npm run dev` & `npm run build` and then loading the generated `.dmg`. Perhaps I'm doing something wrong, if not I'm happy to raise an issue.