### PR TITLE
rm choo-log

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -89,7 +89,6 @@ function create (dir, argv) {
       written.push(path.join(dir, 'node_modules'))
       var pkgs = [
         'choo',
-        'choo-log',
         'choo-devtools',
         'electron-collection',
         'tachyons'
@@ -100,7 +99,7 @@ function create (dir, argv) {
     },
     function (done) {
       var pkgs = [
-        'bankai@next',
+        'bankai',
         'electron',
         'electron-builder',
         'electron-builder-squirrel-windows',

--- a/index.js
+++ b/index.js
@@ -122,7 +122,6 @@ exports.writeIndex = function (dir, cb) {
     var app = choo()
     if (process.env.NODE_ENV !== 'production') {
       app.use(require('choo-devtools')())
-      app.use(require('choo-log')())
     }
 
     app.route('/', require('./views/main'))


### PR DESCRIPTION
Removes `choo-log` from the install step. Depends on https://github.com/choojs/choo-devtools/pull/14, and related to https://github.com/choojs/discuss/issues/2. Thanks!

Sibling PR – https://github.com/choojs/create-choo-app/pull/28