### PR TITLE
Update for windows development

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -101,6 +101,7 @@ function create (dir, argv) {
       var pkgs = [
         'bankai@8',
         'electron',
+        'cross-env',
         'electron-builder',
         'electron-builder-squirrel-windows',
         'standard'

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ exports.writePackage = function (dir, cb) {
       "dev": "bankai start index.js",
       "inspect": "bankai inspect index.js",
       "pack": "bankai build && build --dir",
-      "start": "NODE_ENV=development electron main.js",
+      "start": "cross-env NODE_ENV=development electron main.js",
       "test": "standard && test-deps",
       "test-deps": "dependency-check . && dependency-check . --extra --no-dev -i tachyons"
     },


### PR DESCRIPTION
Added `cross-env` for windows development

----------------------------------------------------------------------

Without these changes, here is the error output

```powershell
> npm run start
```

```powershell
> electric-choo@1.0.0 start D:\storage\code\test\electric-choo
> NODE_ENV=development electron main.js

'NODE_ENV' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! electric-choo@1.0.0 start: `NODE_ENV=development electron main.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the electric-choo@1.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```