### PR TITLE
Set bankai to use electron option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ exports.writePackage = function (dir, cb) {
     "main": "main.js",
     "scripts": {
       "build": "bankai build && build",
-      "dev": "bankai start index.js",
+      "dev": "bankai start index.js --electron",
       "inspect": "bankai inspect index.js",
       "pack": "bankai build && build --dir",
       "start": "NODE_ENV=development electron main.js",


### PR DESCRIPTION
Without this, the renderer process scripts have built-ins (such as `fs`, etc) swapped out or ignored. This prevents the `electron` module from being loaded as internal references to `fs` return `{}`.

This PR alone will not solve issues loading the `electron` module. I created another PR on `bankai` also for excluding the `electron` module from the browserify transform when the electron flag is enabled. https://github.com/choojs/bankai/pull/370