### PR TITLE
Https for bankai v9

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -99,7 +99,7 @@ function create (dir, argv) {
     },
     function (done) {
       var pkgs = [
-        'bankai@8',
+        'bankai@9',
         'electron',
         'electron-builder',
         'electron-builder-squirrel-windows',

--- a/index.js
+++ b/index.js
@@ -179,8 +179,8 @@ exports.writeMain = function (dir, cb) {
       })
     })
 
-    if (process.env === 'development') {
-      app.on('certificate-error', funciton (event, webContents, url, err, cert, cb) {
+    if (process.env.NODE_ENV === 'development') {
+      app.on('certificate-error', function (event, webContents, url, err, cert, cb) {
         if (url.match('https://localhost')) {
           event.preventDefault()
           cb(true)

--- a/index.js
+++ b/index.js
@@ -179,6 +179,17 @@ exports.writeMain = function (dir, cb) {
       })
     })
 
+    if (process.env === 'development') {
+      app.on('certificate-error', funciton (event, webContents, url, err, cert, cb) {
+        if (url.match('https://localhost')) {
+          event.preventDefault()
+          cb(true)
+        } else {
+          cb(false)
+        }
+      })
+    }
+
     app.on('window-all-closed', function () {
       app.quit()
     })

--- a/index.js
+++ b/index.js
@@ -163,7 +163,10 @@ exports.writeMain = function (dir, cb) {
 
     app.on('ready', function () {
       win = new BrowserWindow(windowStyles)
-      win.loadURL('file://' + resolvePath('./index.html'))
+      var root = process.env.NODE_ENV === 'development'
+        ? 'https://localhost:8080'
+        : 'file://' + resolvePath('./index.html')
+      win.loadURL(root)
 
       win.webContents.on('did-finish-load', function () {
         win.show()


### PR DESCRIPTION
I have implemented certificate ignoring mentioned in #8. This should pave the way towards supporting `bankai` v9.

I also included an upgrade to `bankai` v9 as a separate commit. If this https self-signed certificate support is not enough before upgrading to v9, I can remove that commit.